### PR TITLE
initialize the default rank set on TrainerState

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -489,6 +489,11 @@ class Trainer:
             self.label_smoother = None
 
         self.state = TrainerState()
+        
+        # initialize the default rank set on TrainerState
+        self.state.is_local_process_zero = self.is_local_process_zero()
+        self.state.is_world_process_zero = self.is_world_process_zero()
+        
         self.control = TrainerControl()
         # Internal variable to count flos in each process, will be accumulated in `self.state.total_flos` then
         # returned to 0 every time flos need to be logged

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -488,12 +488,11 @@ class Trainer:
         else:
             self.label_smoother = None
 
-        self.state = TrainerState()
-        
-        # initialize the default rank set on TrainerState
-        self.state.is_local_process_zero = self.is_local_process_zero()
-        self.state.is_world_process_zero = self.is_world_process_zero()
-        
+        self.state = TrainerState(
+            is_local_process_zero=self.is_local_process_zero(),
+            is_world_process_zero=self.is_world_process_zero(),
+        )
+
         self.control = TrainerControl()
         # Internal variable to count flos in each process, will be accumulated in `self.state.total_flos` then
         # returned to 0 every time flos need to be logged


### PR DESCRIPTION
# What does this PR do?

This PR fixes this error I'm observing on one azureml experiment:

```python
[stderr]  File "/opt/conda/lib/python3.8/site-packages/transformers/trainer.py", line 508, in __init__
[stderr]    self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
[stderr]  File "/opt/conda/lib/python3.8/site-packages/transformers/trainer_callback.py", line 343, in on_init_end
[stderr]    return self.call_event("on_init_end", args, state, control)
[stderr]  File "/opt/conda/lib/python3.8/site-packages/transformers/trainer_callback.py", line 388, in call_event
[stderr]    result = getattr(callback, event)(
[stderr]  File "/opt/conda/lib/python3.8/site-packages/transformers/integrations.py", line 750, in on_init_end
[stderr]    self.azureml_run = Run.get_context()
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/core/run.py", line 382, in get_context
[stderr]    return _SubmittedRun._get_instance(experiment, run_id, **kwargs)
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/core/run.py", line 2307, in _get_instance
[stderr]    run = _SubmittedRun(experiment, run_id, **kwargs)
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/core/run.py", line 2312, in __init__
[stderr]    super(_SubmittedRun, self).__init__(*args, **kwargs)
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/core/run.py", line 173, in __init__
[stderr]    super(Run, self).__init__(experiment, run_id, outputs=outputs, **kwargs)
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/_run_impl/run_base.py", line 85, in __init__
[stderr]    self._client = RunHistoryFacade(self._experiment, self._run_id, RUN_ORIGIN, run_dto=_run_dto,
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/_run_impl/run_history_facade.py", line 96, in __init__
[stderr]    self.run_dto = run_dto if run_dto is not None else self.run.get_run()
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/_restclient/run_client.py", line 78, in get_run
[stderr]    return super(RunClient, self).get_run(self._run_id, **kwargs)
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/_restclient/experiment_client.py", line 126, in get_run
[stderr]    return self._execute_with_experimentid_arguments(self._client.run.get_by_exp_id,
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/_restclient/experiment_client.py", line 265, in _execute_with_experimentid_arguments
[stderr]    return self._execute_with_arguments(func,
[stderr]  File "/opt/conda/lib/python3.8/site-packages/azureml/_restclient/clientbase.py", line 591, in _execute_with_arguments
[stderr]    raise ServiceException(e)
[stderr]azureml._restclient.exceptions.ServiceException: ServiceException:
[stderr]	Code: 401
[stderr]	Message: Operation returned an invalid status code 'Unauthorized'
[stderr]	Details:
[stderr]
[stderr]	Headers: {
[stderr]	    "Date": "Thu, 31 Mar 2022 20:22:52 GMT",
[stderr]	    "Content-Length": "0",
[stderr]	    "Connection": "keep-alive",
[stderr]	    "WWW-Authenticate": "Bearer authorization_uri=\"https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\", error=\"invalid_token\", error_description=\"The authentication failed because of missing 'Authorization' header.\"",
[stderr]	    "Request-Context": "appId=cid-v1:2d2e8e63-272e-4b3c-8598-4ee570a0e70d",
[stderr]	    "x-ms-response-type": "standard",
[stderr]	    "Strict-Transport-Security": "max-age=15724800; includeSubDomains; preload",
[stderr]	    "X-Content-Type-Options": "nosniff",
[stderr]	    "x-request-time": "0.018"
[stderr]	}
[stderr]	InnerException: {
[stderr]    "additional_properties": {},
[stderr]    "error": null,
[stderr]    "correlation": null,
[stderr]    "environment": null,
[stderr]    "location": null,
[stderr]    "time": null,
[stderr]    "component_name": null
[stderr]}
```

The error appears because `self.callback_handler.on_init_end(self.args, self.state, self.control)` is called without the `self.state` properly initialized


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- albert, bert, xlm: @LysandreJik
- blenderbot, bart, marian, pegasus, encoderdecoder,  t5: @patrickvonplaten, @patil-suraj
- longformer, reformer, transfoxl, xlnet: @patrickvonplaten
- fsmt: @stas00
- funnel: @sgugger
- gpt2: @patrickvonplaten, @LysandreJik
- rag: @patrickvonplaten, @lhoestq
- tensorflow: @LysandreJik

Library:

- benchmarks: @patrickvonplaten
- deepspeed: @stas00
- ray/raytune: @richardliaw, @amogkam
- text generation: @patrickvonplaten
- tokenizers: @n1t0, @LysandreJik
- trainer: @sgugger
- pipelines: @LysandreJik

Documentation: @sgugger

HF projects:

- datasets: [different repo](https://github.com/huggingface/datasets)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Examples:

- maintained examples (not research project or legacy): @sgugger, @patil-suraj
- research_projects/bert-loses-patience: @JetRunner
- research_projects/distillation: @VictorSanh

 -->
